### PR TITLE
[PROPOSAL] Avoid regenerating Jooq classes if the input schema hasn't changed

### DIFF
--- a/jOOQ-codegen-maven/src/main/java/org/jooq/codegen/maven/Plugin.java
+++ b/jOOQ-codegen-maven/src/main/java/org/jooq/codegen/maven/Plugin.java
@@ -42,12 +42,21 @@ import static org.apache.maven.plugins.annotations.ResolutionScope.TEST;
 import static org.jooq.Constants.XSD_CODEGEN;
 import static org.jooq.codegen.GenerationTool.DEFAULT_TARGET_DIRECTORY;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.zip.Adler32;
 
 import org.jooq.codegen.GenerationTool;
 import org.jooq.meta.jaxb.Configuration;
@@ -157,6 +166,30 @@ public class Plugin extends AbstractMojo {
     @Parameter
     private org.jooq.meta.jaxb.Generator generator;
 
+    /**
+     * Files in the directories specified here should exhaustively
+     * define all schemas, Jooq Codegen Maven plugin will use these
+     * files to compute the checksum.
+     * When Jooq classes are generated, Jooq will also add a file
+     * with the checksum of these schema definitions, this way when
+     * recompiling the codebase again you will not have to get up
+     * the testcontainer, apply all migrations and regenerate Jooq classes.
+     * Unless one of the SQL files is changed or a new one is added.
+     */
+    @Parameter(
+            property = "jooq.codegen.schemaDefinitionInputs"
+    )
+    private List<String> schemaDefinitionInputs;
+
+    /**
+     * Specify this to force generation of Jooq classes even if the
+     * checksum hasn't changed.
+     */
+    @Parameter(
+            property = "jooq.codegen.forceGenerate"
+    )
+    private boolean forceGenerate;
+
     @Override
     public void execute() throws MojoExecutionException {
         if (skip) {
@@ -213,7 +246,15 @@ public class Plugin extends AbstractMojo {
             if (getLog().isDebugEnabled())
                 getLog().debug("Using this configuration:\n" + configuration);
 
-            GenerationTool.generate(configuration);
+            int configurationHashCode = configuration.toString().hashCode();
+            String targetDirectory = generator.getTarget().getDirectory();
+
+            if (shouldRegenerateAccordingToInputChecksum(configurationHashCode, targetDirectory)) {
+                Set<String> outFiles = GenerationTool.generate(configuration);
+                saveChecksumFile(configurationHashCode, targetDirectory, outFiles);
+            } else {
+                getLog().info("Skipping class generation, because file digests match");
+            }
         }
         catch (Exception ex) {
             throw new MojoExecutionException("Error running jOOQ code generation tool", ex);
@@ -270,5 +311,131 @@ public class Plugin extends AbstractMojo {
         catch (Exception e) {
             throw new MojoExecutionException("Couldn't create a classloader.", e);
         }
+    }
+
+    /**
+     * Validate all files in the schemaDefinitionInputs directories, by constructing a checksum
+     * of these files and verifying that the target directory already contains that checksum.
+     * If the target directory doesn't contain the checksum, or checksums don't match, then
+     * we need to regenerate Jooq classes.
+     */
+    private boolean shouldRegenerateAccordingToInputChecksum(int configurationHashCode, String targetDirectory) {
+        if (forceGenerate || schemaDefinitionInputs == null || schemaDefinitionInputs.isEmpty())
+            return true;
+
+        // Checksum file contains:
+        // 1. first line is a checksum hash, which is calculated based on the current Jooq
+        //     configuration and on the checksum of all input files
+        // 2. subsequent lines are filenames
+
+        File checksumFile = Paths.get(project.getBasedir().getPath(), targetDirectory, ".jooq-checksum").toFile();
+        if (!checksumFile.exists() || !checksumFile.isFile()) {
+            getLog().info("Checksum file doesn't exist, will regenerate Jooq classes.");
+            return true;
+        }
+
+        String savedChecksum;
+        Set<String> generatedFiles = new HashSet<>();
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(checksumFile))) {
+            String checksumLine = reader.readLine();
+            if (checksumLine == null) {
+                getLog().info("The checksum file is empty, will regenerate Jooq classes.");
+                return true;
+            }
+
+            savedChecksum = checksumLine.trim();
+            reader.lines().filter(s -> !s.isEmpty()).forEach(generatedFiles::add);
+        } catch (IOException e) {
+            getLog().warn("Couldn't read checksum file. If you're unsure " +
+                    "how to solve this issue, try removing the .jooq-checksum file", e);
+            return true;
+        }
+
+        String currentInputFilesChecksum;
+        try {
+            currentInputFilesChecksum = calculateInputSchemaDefinitionsChecksum(configurationHashCode);
+        } catch (MojoExecutionException e) {
+            getLog().warn("Couldn't calculate the current checksum.", e);
+            return true;
+        }
+
+        if (!savedChecksum.equals(currentInputFilesChecksum)) {
+            getLog().info("Checksums didn't match, will regenerate Jooq classes.");
+            return true;
+        }
+
+        // once we see that checksums match, we just want to ensure that the files are still actually there
+
+        for (String generatedFile : generatedFiles) {
+            if (Files.notExists(Paths.get(generatedFile))) {
+                getLog().info("Detected that a generated file " + generatedFile
+                        + " doesn't exist anymore, will regenerate Jooq classes.");
+                return true;
+            }
+        }
+
+        getLog().info("Checksums matched, all generated files exist, will skip " +
+                "regeneration of Jooq classes.");
+
+        return false;
+    }
+
+    private void saveChecksumFile(int configurationHashCode, String targetDirectory, Set<String> generatedFiles) {
+        if (schemaDefinitionInputs == null || schemaDefinitionInputs.isEmpty())
+            return;
+
+        String inputDefinitionsChecksum;
+        try {
+            inputDefinitionsChecksum = calculateInputSchemaDefinitionsChecksum(configurationHashCode);
+        } catch (MojoExecutionException e) {
+            getLog().warn("Couldn't calculate the current checksum.", e);
+            return;
+        }
+
+        byte[] lineSeparator = System.lineSeparator().getBytes();
+        try (FileOutputStream os = new FileOutputStream(Paths.get(project.getBasedir().getPath(), targetDirectory, ".jooq-checksum").toFile(), false)) {
+            os.write(inputDefinitionsChecksum.getBytes());
+            os.write(lineSeparator);
+
+            for (String generatedFile : generatedFiles) {
+                os.write(generatedFile.getBytes());
+                os.write(lineSeparator);
+            }
+        } catch (IOException e) {
+            getLog().warn("Couldn't write to the .jooq-checksum file", e);
+        }
+    }
+
+    private String calculateInputSchemaDefinitionsChecksum(int configurationHashCode)
+            throws MojoExecutionException {
+        Adler32 checksum = new Adler32();
+        checksum.update(configurationHashCode);
+        for (String schemaDefinitionsInputDirectory : schemaDefinitionInputs) {
+            List<String> schemaDefinitionFiles;
+            try {
+                schemaDefinitionFiles = Files.walk(Paths.get(schemaDefinitionsInputDirectory))
+                        .filter(p -> p.toFile().isFile())
+                        .map(Path::toString)
+                        .sorted()
+                        .toList();
+            } catch (IOException e) {
+                throw new MojoExecutionException("Couldn't list files under the directory "
+                        + schemaDefinitionsInputDirectory, e);
+            }
+
+            for (String schemaFile : schemaDefinitionFiles) {
+                checksum.update(schemaFile.getBytes());
+
+                try {
+                    checksum.update(Files.readAllBytes(Paths.get(schemaFile)));
+                } catch (IOException e) {
+                    throw new MojoExecutionException("Couldn't read " + schemaFile
+                            + " while calculating the checksum.", e);
+                }
+            }
+        }
+
+        return Long.toString(checksum.getValue());
     }
 }

--- a/jOOQ-codegen/src/main/java/org/jooq/codegen/AbstractGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/codegen/AbstractGenerator.java
@@ -44,6 +44,7 @@ import java.io.File;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -186,16 +187,21 @@ abstract class AbstractGenerator implements Generator {
     }
 
     @Override
-    public void generate(Database db) {
+    public Set<String> generate(Database db) {
         this.database = db;
 
         this.database.setIncludeRelations(generateRelations());
         this.database.setTableValuedFunctions(generateTableValuedFunctions());
 
-        generate0(db);
+        return generate0(db);
     }
 
-    protected void generate0(Database db) {}
+    /**
+     * @return a set of relative file paths of files that were generated
+     */
+    protected Set<String> generate0(Database db) {
+        return new HashSet<>();
+    }
 
     void logDatabaseParameters(Database db) {
         String url = "";

--- a/jOOQ-codegen/src/main/java/org/jooq/codegen/Generator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/codegen/Generator.java
@@ -40,6 +40,7 @@ package org.jooq.codegen;
 
 import java.io.Serializable;
 import java.util.Locale;
+import java.util.Set;
 
 import org.jooq.Condition;
 import org.jooq.Constants;
@@ -69,8 +70,9 @@ public interface Generator {
 
     /**
      * Do the code generation
+     * @return a set of relative file paths of files that were generated
      */
-    void generate(Database database);
+    Set<String> generate(Database database);
 
     /**
      * Set a naming strategy to this generator

--- a/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/codegen/JavaGenerator.java
@@ -422,7 +422,7 @@ public class JavaGenerator extends AbstractGenerator {
     }
 
     @Override
-    public final void generate0(Database db) {
+    public final Set<String> generate0(Database db) {
         this.isoDate = Instant.now().toString();
         this.schemaVersions = new LinkedHashMap<>();
         this.catalogVersions = new LinkedHashMap<>();
@@ -560,7 +560,11 @@ public class JavaGenerator extends AbstractGenerator {
         log.info("Removing excess files");
         empty(getStrategy().getFileRoot(), (scala ? ".scala" : kotlin ? ".kt" : ".java"), affectedFiles, directoriesNotForRemoval);
         directoriesNotForRemoval.clear();
+
+        Set<String> outFiles = affectedFiles.stream().map(File::getPath).collect(Collectors.toSet());
         affectedFiles.clear();
+
+        return outFiles;
     }
 
     private boolean generateCatalogIfEmpty(CatalogDefinition catalog) {

--- a/jOOQ-codegen/src/main/java/org/jooq/codegen/XMLGenerator.java
+++ b/jOOQ-codegen/src/main/java/org/jooq/codegen/XMLGenerator.java
@@ -47,7 +47,9 @@ import static org.jooq.util.xml.jaxb.TableConstraintType.UNIQUE;
 
 import java.io.StringWriter;
 import java.math.BigInteger;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.jooq.SortOrder;
 import org.jooq.meta.CatalogDefinition;
@@ -100,7 +102,7 @@ public class XMLGenerator extends AbstractGenerator {
     }
 
     @Override
-    public void generate0(Database db) {
+    public Set<String> generate0(Database db) {
         logDatabaseParameters(db);
         log.info("");
         logGenerationRemarks(db);
@@ -405,6 +407,12 @@ public class XMLGenerator extends AbstractGenerator {
         MiniJAXB.marshal(is, writer);
         out.print(writer.toString());
         out.close();
+
+        String filename = out.file().getPath();
+        Set<String> outFiles = new HashSet<>();
+        outFiles.add(filename);
+
+        return outFiles;
     }
 
     private void exportRoutine(InformationSchema is, RoutineDefinition r, String catalogName, String schemaName) {

--- a/jOOQ-examples/jOOQ-testcontainers-example/pom.xml
+++ b/jOOQ-examples/jOOQ-testcontainers-example/pom.xml
@@ -103,6 +103,9 @@
                                 <user>${db.username}</user>
                                 <password>${db.password}</password>
                             </jdbc>
+                            <schemaDefinitionInputs>
+                                <schemaDefinitionInput>${project.basedir}/src/main/resources</schemaDefinitionInput>
+                            </schemaDefinitionInputs>
                             <generator>
                                 <database>
                                     <inputSchema>public</inputSchema>


### PR DESCRIPTION
This is a demo implementation to complement a feature request.

Some anticipated questions:

> Does this work?

Yes! This will succesfully prevents a startup of a testcontainer, and the whole code regeneration phase when Jooq's class sources already exist and the migrations didn't change.

> Is this a good idea for CI?

No, you want a full clean rebuild in CI when it comes to sensitive things like this one.